### PR TITLE
Fix YouTube pagination and duration parsing

### DIFF
--- a/background.js
+++ b/background.js
@@ -111,7 +111,7 @@ function main(startDate = new Date(new Date() - 604800000)) {
         console.log('New Videos:', list)
         // console.log(list.map(e => `${formatDate(e.pubDate)}`).join("\n"))
         console.log(list.map(e => [
-          parseDuration(formatDate(e.duration)),
+          parseDuration(e.duration),
           formatDate(e.pubDate),
           e.channelTitle,
           e.title,

--- a/youTubeApiConnectors.js
+++ b/youTubeApiConnectors.js
@@ -82,8 +82,9 @@ function getNewVideos(
             };
           })
           .filter((item) => item.pubDate > startDate);
-        if (response.totalResults == newVid.length && response.nextPageToken) {
-          return getNewVideos(playlist, startDate, response.nextPageToken).then(
+        const pageInfo = response.result.pageInfo;
+        if (pageInfo && pageInfo.totalResults == newVid.length && response.result.nextPageToken) {
+          return getNewVideos(playlist, startDate, response.result.nextPageToken).then(
             (e) => newVid.concat(e)
           );
         } else {
@@ -215,8 +216,8 @@ function getVideoInfo(idList, nextP) {
               liveStreamingDetails: el.liveStreamingDetails,
             };
           });
-        if (response.nextPageToken) {
-          return getVideoInfo(idList, response.nextPageToken).then((e) =>
+        if (response.result.nextPageToken) {
+          return getVideoInfo(idList, response.result.nextPageToken).then((e) =>
             info.concat(e)
           );
         } else {

--- a/youTubeApiConnectors.js
+++ b/youTubeApiConnectors.js
@@ -69,7 +69,7 @@ function getNewVideos(
       part: "contentDetails",
       maxResults: 50,
       playlistId: playlist,
-      nextPageToken: nextP,
+      pageToken: nextP,
     })
     .then(
       function (response) {


### PR DESCRIPTION
## Summary
- correct duration output in debug log
- properly read `nextPageToken` and `pageInfo.totalResults`

## Testing
- `node -e "require('./youTubeApiConnectors.js')"`
- `node -e "var chrome={storage:{sync:{get:(a,b)=>b({}),set:(o,cb)=>cb&&cb()},local:{get:(a,b)=>b({}),set:(o)=>{}}},browserAction:{onClicked:{removeListener:()=>{},addListener:()=>{}}},runtime:{},notifications:{create:()=>{}}}; try{require('./background.js');}catch(e){}`

------
https://chatgpt.com/codex/tasks/task_e_684bde410268832687ffb35521404e84