### PR TITLE
Refactor background to modules

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -1,8 +1,13 @@
 // Manage OAuth token using chrome.identity without gapi
-chrome.storage.local.set({ authStatus: false });
+if (typeof chrome !== 'undefined') {
+  chrome.storage.local.set({ authStatus: false });
+}
 let currentToken = null;
 
-function signInUser() {
+export function signInUser() {
+  if (typeof chrome === 'undefined') {
+    return Promise.reject(new Error('chrome API unavailable'));
+  }
   return new Promise((resolve, reject) => {
     chrome.identity.getAuthToken({ interactive: true }, token => {
       if (chrome.runtime.lastError || !token) {
@@ -18,7 +23,10 @@ function signInUser() {
   });
 }
 
-function getToken() {
+export function getToken() {
+  if (typeof chrome === 'undefined') {
+    return Promise.reject(new Error('chrome API unavailable'));
+  }
   if (currentToken) return Promise.resolve(currentToken);
   return new Promise((resolve, reject) => {
     chrome.identity.getAuthToken({ interactive: false }, token => {

--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,8 @@
     "default_popup": "popup/popup.html"
   },
   "background": {
-    "service_worker": "background.js"
+    "service_worker": "background.js",
+    "type": "module"
   },
   "oauth2": {
     "client_id": "63911817448-jqopokpb65qot40t4h4mlde2nlbphmkc.apps.googleusercontent.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "ytautoplaylist",
   "version": "1.0.0",
+  "type": "module",
   "scripts": {
     "test": "node tests/test.js"
   }

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,8 +1,8 @@
-const assert = require('assert');
-const api = require('../youTubeApiConnectors.js');
+import assert from 'assert';
+import { getNewVideos, __setCallApi } from '../youTubeApiConnectors.js';
 
 const calls = [];
-api.__setCallApi(async (path) => {
+__setCallApi(async (path) => {
   calls.push(path);
   if (path === 'playlistItems') {
     const err = new Error('API playlistItems failed');
@@ -15,7 +15,7 @@ api.__setCallApi(async (path) => {
 });
 
 (async () => {
-  const res = await api.getNewVideos('UUstub');
+  const res = await getNewVideos('UUstub');
   assert.deepStrictEqual(res, { videos: [], pages: 1 });
   assert.deepStrictEqual(calls, ['playlistItems', 'search']);
   console.log('getNewVideos falls back to search');

--- a/youTubeApiConnectors.js
+++ b/youTubeApiConnectors.js
@@ -1,3 +1,5 @@
+import { getToken } from './auth.js';
+
 // Utility for calling YouTube Data API via fetch
 async function callApi(path, params = {}, method = 'GET', body = null) {
   const token = await getToken();
@@ -231,10 +233,20 @@ async function getVideoInfo(idList, nextPage) {
   return info;
 }
 
-if (typeof module !== 'undefined') {
-  module.exports = {
-    getNewVideos,
-    __setCallApi: fn => callApi = fn
-  };
+export function __setCallApi(fn) {
+  callApi = fn;
 }
+
+export {
+  getSubscriptionsId,
+  getUploadsLists,
+  getRecentVideosBySearch,
+  getNewVideos,
+  logMessage,
+  addListToWL,
+  createPlayList,
+  addVideoToWL,
+  isShort,
+  getVideoInfo
+};
 


### PR DESCRIPTION
## Summary
- convert extension to ES modules
- clean up background script and comments
- add guard code for auth when chrome APIs are unavailable
- adjust tests to import modules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c6792ebbc8326bb091d140616067a