### PR TITLE
Improve filtering mechanism

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,33 +1,51 @@
-export const TITLEFILTER = {
-  "UC7Elc-kLydl-NAV4g204pDQ": ["новости |", "военное положение |"],
-  "UCt7sv-NKh44rHAEb-qCCxvA": ["ostronews", "iphone"],
-  UC8zQiuT0m1TELequJ5sp5zw: ["подкаст", "подкаст", "спецэфир"],
-  "UC3cJiUuZlpF-pkzqvSskTpg": ["разгоны #", "чувс", "книжный клуб"],
-  "UCixlrqz8w-oa4UzdKyHLMaA": ["yet another podcast"],
-  "UCn9bv143ECsDMw-kJCNN7QA": ["подземелья чикен"],
-};
-
-export const BROADCASTFILTER = [
-  "UC7Elc-kLydl-NAV4g204pDQ",
-  "UCt7sv-NKh44rHAEb-qCCxvA",
-  "UCUGfDbfRIx51kJGGHIFo8Rw",
-  "UCBG57608Hukev3d0d-gvLhQ",
-  "UCjQdM9q_Vd2gBN9Xy_zRDJQ",
-  "UCKRC-fNrU-XvZTrwXN4Xxcg",
-  "UC5EgIZja1sE3IF9U_CKEVew",
-  "UCBq6jERElPLXL5cEy-sA9Tw",
-  "UC6uFoHcr_EEK6DgCS-LeTNA",
-  "UCY649zJeJVhhJa-rvWThZ2g",
-  "UCUmlB9SwrBVevETZV0wrVRw",
-  "UCQ_LYRUJzBfh-mvU14xCNMw",
-  "UCTUyoZMfksbNIHfWJjwr5aQ",
-];
-
-export const TAGFILTER = {
-  UCUGfDbfRIx51kJGGHIFo8Rw: ["сводка"],
-};
-
-export const LENFILTER = {
-  "UCBG57608Hukev3d0d-gvLhQ": [{ min: 0, max: 50 * 60 }],
-  UCXoAjrdHFa2hEL3Ug8REC1w: [{ min: 0, max: 29 * 60 }],
+export const FILTERS = {
+  global: {
+    noShorts: true,
+    noBroadcasts: false,
+    title: [],
+    tags: [],
+    duration: [],
+  },
+  channels: {
+    "UC7Elc-kLydl-NAV4g204pDQ": {
+      title: ["новости |", "военное положение |"],
+      noBroadcasts: true,
+    },
+    "UCt7sv-NKh44rHAEb-qCCxvA": {
+      title: ["ostronews", "iphone"],
+      noBroadcasts: true,
+    },
+    UC8zQiuT0m1TELequJ5sp5zw: {
+      title: ["подкаст", "подкаст", "спецэфир"],
+    },
+    "UC3cJiUuZlpF-pkzqvSskTpg": {
+      title: ["разгоны #", "чувс", "книжный клуб"],
+    },
+    "UCixlrqz8w-oa4UzdKyHLMaA": {
+      title: ["yet another podcast"],
+    },
+    "UCn9bv143ECsDMw-kJCNN7QA": {
+      title: ["подземелья чикен"],
+    },
+    UCUGfDbfRIx51kJGGHIFo8Rw: {
+      noBroadcasts: true,
+      tags: ["сводка"],
+    },
+    "UCBG57608Hukev3d0d-gvLhQ": {
+      noBroadcasts: true,
+      duration: [{ min: 0, max: 50 * 60 }],
+    },
+    UCjQdM9q_Vd2gBN9Xy_zRDJQ: { noBroadcasts: true },
+    UCKRC-fNrU-XvZTrwXN4Xxcg: { noBroadcasts: true },
+    UC5EgIZja1sE3IF9U_CKEVew: { noBroadcasts: true },
+    UCBq6jERElPLXL5cEy-sA9Tw: { noBroadcasts: true },
+    UC6uFoHcr_EEK6DgCS-LeTNA: { noBroadcasts: true },
+    UCY649zJeJVhhJa-rvWThZ2g: { noBroadcasts: true },
+    UCUmlB9SwrBVevETZV0wrVRw: { noBroadcasts: true },
+    UCQ_LYRUJzBfh-mvU14xCNMw: { noBroadcasts: true },
+    UCTUyoZMfksbNIHfWJjwr5aQ: { noBroadcasts: true },
+    UCXoAjrdHFa2hEL3Ug8REC1w: {
+      duration: [{ min: 0, max: 29 * 60 }],
+    },
+  },
 };


### PR DESCRIPTION
## Summary
- restructure filter constants to support global and per-channel settings
- extend `filterVideos` to apply title, tag, duration, shorts and broadcast filters

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d62bf2cd08326b49a6d3b8a624fcc