### PR TITLE
Fix channel card layout for filter buttons

### DIFF
--- a/src/settings/settings.js
+++ b/src/settings/settings.js
@@ -244,29 +244,36 @@ document.addEventListener("DOMContentLoaded", async () => {
     addLabel.textContent = "Добавить фильтры:";
     addRow.appendChild(addLabel);
 
+    let btnContainer = addRow;
+    if (channelId) {
+      btnContainer = document.createElement("div");
+      btnContainer.className = "top-row";
+    }
+
     const btnDur = document.createElement("button");
     btnDur.type = "button";
     btnDur.className = "button is-small is-info";
     btnDur.innerHTML =
       '<span class="icon"><i class="fas fa-plus"></i></span><span>Длительность</span>';
-    addRow.appendChild(btnDur);
+    btnContainer.appendChild(btnDur);
 
     const btnTitle = document.createElement("button");
     btnTitle.type = "button";
     btnTitle.className = "button is-small is-info";
     btnTitle.innerHTML =
       '<span class="icon"><i class="fas fa-plus"></i></span><span>Заголовок</span>';
-    addRow.appendChild(btnTitle);
+    btnContainer.appendChild(btnTitle);
 
     const btnTag = document.createElement("button");
     btnTag.type = "button";
     btnTag.className = "button is-small is-info";
     btnTag.innerHTML =
       '<span class="icon"><i class="fas fa-plus"></i></span><span>Тег</span>';
-    addRow.appendChild(btnTag);
+    btnContainer.appendChild(btnTag);
 
     box.appendChild(topRow);
     box.appendChild(addRow);
+    if (channelId) box.appendChild(btnContainer);
 
     const durGroup = createGroup(
       "Длительность",


### PR DESCRIPTION
## Summary
- adjust layout in `createSection` so channel cards show filter buttons on a new line

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684dce1accd08326b3053f27fc48cf73