### PR TITLE
Fix channel card text input width

### DIFF
--- a/src/settings/settings.html
+++ b/src/settings/settings.html
@@ -52,11 +52,19 @@
         align-items: center;
         justify-content: center;
       }
+      .filter-card.box .filter-row .remove-row {
+        margin-right: 0;
+      }
       .filter-row .input[type="time"] {
         width: 7rem;
       }
       .filter-row .input[type="text"] {
         width: 24rem;
+      }
+      .filter-card.box .filter-row .input[type="text"] {
+        width: auto;
+        flex: 1 1 auto;
+        min-width: 0;
       }
       .filter-group {
         margin-bottom: 0.5rem;

--- a/src/settings/settings.html
+++ b/src/settings/settings.html
@@ -80,6 +80,13 @@
         flex-wrap: wrap;
         gap: 0.5rem;
       }
+      .filter-card.box .rows-wrap {
+        flex-direction: column;
+        flex-wrap: nowrap;
+      }
+      .filter-card.box .filter-row {
+        width: 100%;
+      }
       #filtersContainer {
         display: flex;
         flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- make delete button margin-free for channel filter rows
- stretch channel title/tag inputs to fill available space

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dd80e82108326913da0ca52ca11ef