### PR TITLE
Fix spacing for empty filter groups

### DIFF
--- a/src/settings/settings.js
+++ b/src/settings/settings.js
@@ -109,7 +109,9 @@ function createGroup(labelText, type, rows, createRowFn) {
   group.appendChild(list);
 
   function checkHeader() {
-    header.style.display = list.children.length ? "" : "none";
+    const hasRows = list.children.length > 0;
+    header.style.display = hasRows ? "" : "none";
+    group.style.display = hasRows ? "" : "none";
   }
 
   addBtn.addEventListener("click", () => {


### PR DESCRIPTION
## Summary
- hide filter group sections when there are no rows

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ea24e9be88326b621794354bfc3c1