### PR TITLE
Refactor options layout

### DIFF
--- a/src/settings/settings.html
+++ b/src/settings/settings.html
@@ -12,34 +12,7 @@
     <title>YT AutoWL settings</title>
     <style>
       .filter-card {
-        --gap: 0.75rem;
-        padding: 0.75rem;
         position: relative;
-        flex: 0 0 calc((100% - 3 * var(--gap)) / 4);
-        max-width: calc((100% - 3 * var(--gap)) / 4);
-        min-width: 260px;
-      }
-      .filter-card.wide {
-        flex: 1 0 100%;
-        max-width: 100%;
-      }
-      @media (max-width: 1407px) {
-        .filter-card {
-          flex: 0 0 calc((100% - 2 * var(--gap)) / 3);
-          max-width: calc((100% - 2 * var(--gap)) / 3);
-        }
-      }
-      @media (max-width: 1023px) {
-        .filter-card {
-          flex: 0 0 calc((100% - var(--gap)) / 2);
-          max-width: calc((100% - var(--gap)) / 2);
-        }
-      }
-      @media (max-width: 639px) {
-        .filter-card {
-          flex: 1 0 100%;
-          max-width: 100%;
-        }
       }
       .top-row {
         display: flex;
@@ -53,31 +26,12 @@
         align-items: center;
         gap: 0.5rem;
         margin-bottom: 0.5rem;
-        flex: 0 0 auto;
-      }
-      .filter-row .remove-row {
-        margin-right: 1rem;
-        border-radius: 50%;
-        padding: 0;
-        width: 1.5em;
-        height: 1.5em;
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-      }
-      .filter-card.box .filter-row .remove-row {
-        margin-right: 0;
       }
       .filter-row .input[type="time"] {
         width: 7rem;
       }
       .filter-row .input[type="text"] {
-        width: 24rem;
-      }
-      .filter-card.box .filter-row .input[type="text"] {
-        width: auto;
         flex: 1 1 auto;
-        min-width: 0;
       }
       .filter-group {
         margin-bottom: 0.5rem;
@@ -90,24 +44,8 @@
       }
       .rows-wrap {
         display: flex;
-        flex-wrap: wrap;
-        gap: 0.5rem;
-      }
-      .filter-card.box .rows-wrap {
         flex-direction: column;
-        flex-wrap: nowrap;
-      }
-      .filter-card.box .filter-row {
-        width: 100%;
-      }
-      .filter-card.box {
-        margin-bottom: 0;
-      }
-      #filtersContainer {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 0.75rem;
-        justify-content: center;
+        gap: 0.5rem;
       }
       .remove-btn {
         position: absolute;
@@ -118,14 +56,7 @@
         box-shadow: none;
         border: 1px dashed #ccc;
         text-align: center;
-        margin-bottom: 0;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        gap: 0.5rem;
       }
-
       #filtersButtons .buttons {
         align-items: center;
         justify-content: center;
@@ -141,7 +72,6 @@
         display: inline-flex;
         flex-wrap: wrap;
         gap: 0.5rem;
-        max-width: 100%;
       }
     </style>
   </head>
@@ -266,8 +196,8 @@
  
 
       <div class="container is-fluid px-0">
-        <div id="filtersContainer">
-          <div id="addChannelCard" class="box filter-card add-card">
+        <div id="filtersContainer" class="columns is-multiline is-variable is-3 is-hidden">
+          <div id="addChannelCard" class="column is-one-quarter-desktop is-half-tablet is-full-mobile box filter-card add-card">
             <div class="group-header">
               <span class="has-text-weight-bold">Фильтровать другой канал</span>
             </div>

--- a/src/settings/settings.js
+++ b/src/settings/settings.js
@@ -52,10 +52,8 @@ function createDurationRow(min = 0, max = Infinity) {
   row.appendChild(to);
 
   const del = document.createElement("button");
-  del.className = "button is-white is-small remove-row";
+  del.className = "delete is-small remove-row";
   del.type = "button";
-  del.innerHTML =
-    '<span class="icon"><svg width="1.5em" height="1.5em"><use href="icons.svg#icon-x" /></svg></span>';
   del.addEventListener("click", () => row.remove());
   row.appendChild(del);
 
@@ -74,10 +72,8 @@ function createTextRow(type, value = "") {
   row.appendChild(input);
 
   const del = document.createElement("button");
-  del.className = "button is-white is-small remove-row";
+  del.className = "delete is-small remove-row";
   del.type = "button";
-  del.innerHTML =
-    '<span class="icon"><svg width="1.5em" height="1.5em"><use href="icons.svg#icon-x" /></svg></span>';
   del.addEventListener("click", () => row.remove());
   row.appendChild(del);
 
@@ -196,7 +192,16 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   function createSection(title, data = {}, channelId) {
     const box = document.createElement("div");
-    box.className = channelId ? "box filter-card" : "filter-card wide";
+    box.className = "column box filter-card";
+    if (channelId) {
+      box.classList.add(
+        "is-one-quarter-desktop",
+        "is-half-tablet",
+        "is-full-mobile"
+      );
+    } else {
+      box.classList.add("is-full");
+    }
     box.dataset.channel = channelId || "";
 
     if (channelId) {
@@ -214,9 +219,8 @@ document.addEventListener("DOMContentLoaded", async () => {
     topRow.className = "top-row";
     if (channelId) {
       const remove = document.createElement("button");
-      remove.className = "button is-danger is-light is-small remove-btn";
+      remove.className = "delete remove-btn";
       remove.type = "button";
-      remove.innerHTML = '<span class="icon"><svg width="1.5em" height="1.5em"><use href="icons.svg#icon-trash" /></svg></span>';
       remove.addEventListener("click", () => {
         box.remove();
         const opt = document.createElement("option");
@@ -339,6 +343,8 @@ document.addEventListener("DOMContentLoaded", async () => {
     const opt = addChannelSelect.querySelector(`option[value="${id}"]`);
     if (opt) opt.remove();
   });
+
+  filtersContainer.classList.remove("is-hidden");
 
   saveFiltersBtn?.addEventListener("click", () => {
     const sections = document.querySelectorAll(".filter-card:not(.add-card)");


### PR DESCRIPTION
## Summary
- streamline Bulma CSS usage on the options page
- simplify DOM layout and hide filter cards until ready
- use Bulma delete buttons for removing entries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ea4a42a048326b0a3a4d4b78bdb32