### PR TITLE
Add playlist filtering

### DIFF
--- a/src/settings/settings.html
+++ b/src/settings/settings.html
@@ -347,6 +347,12 @@
               </span>
               <span>Тег</span>
             </button>
+            <button type="button" class="button is-small is-info add-playlist">
+              <span class="icon">
+                <svg width="1.5em" height="1.5em"><use href="icons.svg#icon-plus" /></svg>
+              </span>
+              <span>Плейлист</span>
+            </button>
           </div>
         </div>
         <div class="groups-container"></div>
@@ -367,6 +373,18 @@
     <template id="textRowTemplate">
       <div class="filter-row">
         <input type="text" class="input" />
+        <button type="button" class="button is-white is-small remove-row">
+          <span class="icon">
+            <svg width="1.5em" height="1.5em"><use href="icons.svg#icon-x" /></svg>
+          </span>
+        </button>
+      </div>
+    </template>
+    <template id="playlistRowTemplate">
+      <div class="filter-row" data-type="playlist">
+        <div class="select is-fullwidth">
+          <select></select>
+        </div>
         <button type="button" class="button is-white is-small remove-row">
           <span class="icon">
             <svg width="1.5em" height="1.5em"><use href="icons.svg#icon-x" /></svg>

--- a/src/youTubeApiConnectors.js
+++ b/src/youTubeApiConnectors.js
@@ -351,6 +351,31 @@ async function getVideoInfo(idList, nextPage) {
   return info;
 }
 
+async function listChannelPlaylists(channelId, nextPage) {
+  const data = await callApi("playlists", {
+    part: "id,snippet",
+    channelId,
+    maxResults: 50,
+    pageToken: nextPage,
+  });
+  const items = data.items.map((it) => ({ id: it.id, title: it.snippet.title }));
+  if (data.nextPageToken) {
+    const rest = await listChannelPlaylists(channelId, data.nextPageToken);
+    return items.concat(rest);
+  }
+  return items;
+}
+
+async function isVideoInPlaylist(videoId, playlistId) {
+  const data = await callApi("playlistItems", {
+    part: "id",
+    maxResults: 25,
+    playlistId,
+    videoId,
+  });
+  return Array.isArray(data.items) && data.items.length > 0;
+}
+
 export function __setCallApi(fn) {
   callApi = fn;
 }
@@ -365,5 +390,7 @@ export {
   addVideoToWL,
   isShort,
   getVideoInfo,
+  listChannelPlaylists,
+  isVideoInPlaylist,
   getChannelMap,
 };


### PR DESCRIPTION
## Summary
- support checking video in playlists via YouTube API
- add cached playlist retrieval
- extend filter logic with playlist checks
- update options page UI for playlist filters
- test playlist helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68545234d0d88326950b24d07607cf0d