### PR TITLE
Add video info checker to settings

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -71,7 +71,21 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
       }
       getVideoInfo([id])
         .then((info) => {
-          sendResponse({ info: info[0] });
+          const v = info[0];
+          const data = {
+            id: v.id,
+            channelId: v.channelId,
+            channelTitle: v.channelTitle,
+            title: v.title,
+            duration: v.duration,
+            tags: v.tags,
+            publishedAt: v.publishedAt,
+          };
+          if (v.liveStreamingDetails) {
+            data.scheduled = v.liveStreamingDetails.scheduledStartTime;
+            data.actual = v.liveStreamingDetails.actualStartTime;
+          }
+          sendResponse({ info: data });
         })
         .catch((err) => {
           console.error("Failed to get video info", err);

--- a/src/background.js
+++ b/src/background.js
@@ -63,6 +63,22 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         });
       return true;
     }
+    case "videoInfo": {
+      const id = parseVideoId(request.videoId);
+      if (!id) {
+        sendResponse({ error: "Invalid video ID" });
+        return true;
+      }
+      getVideoInfo([id])
+        .then((info) => {
+          sendResponse({ info: info[0] });
+        })
+        .catch((err) => {
+          console.error("Failed to get video info", err);
+          sendResponse({ error: err.message });
+        });
+      return true;
+    }
     case "getLogs":
       sendResponse({ logs: logMessages });
       return true;

--- a/src/settings/settings.html
+++ b/src/settings/settings.html
@@ -213,10 +213,13 @@
           </div>
         </div>
 
+        <h3 class="title is-4 mb-2" id="checkVideoHeader">Проверить видео</h3>
+        <p class="mb-3">
+          Введите ссылку или ID ролика. Здесь отображаются только параметры
+          видео, которые участвуют в фильтрации.
+        </p>
         <div class="mb-4">
-          <label class="mb-1" for="checkVideoInput"
-            >Проверить видео - получить информацию</label
-          >
+          <label class="mb-1" for="checkVideoInput">Ссылка или ID видео</label>
           <div class="field has-addons is-flex-wrap-wrap">
             <div class="control is-expanded">
               <input

--- a/src/settings/settings.html
+++ b/src/settings/settings.html
@@ -155,9 +155,6 @@
       #checkVideoResult {
         white-space: pre-wrap;
       }
-      #checkVideoResult code {
-        margin-right: 0.25rem;
-      }
     </style>
   </head>
   <body>

--- a/src/settings/settings.html
+++ b/src/settings/settings.html
@@ -213,6 +213,28 @@
           </div>
         </div>
 
+        <div class="mb-4">
+          <label class="mb-1" for="checkVideoInput"
+            >Проверить видео - получить информацию</label
+          >
+          <div class="field has-addons is-flex-wrap-wrap">
+            <div class="control is-expanded">
+              <input
+                id="checkVideoInput"
+                class="input"
+                type="text"
+                placeholder="ID или ссылка на видео"
+              />
+            </div>
+            <div class="control">
+              <button id="checkVideoBtn" class="button is-link" type="button">
+                Проверить видео
+              </button>
+            </div>
+          </div>
+          <pre id="checkVideoResult" class="mt-2"></pre>
+        </div>
+
         <h3 class="title is-4 mb-2" id="filtersHeader">Настройки фильтров</h3>
         <div class="content">
           <ul>

--- a/src/settings/settings.html
+++ b/src/settings/settings.html
@@ -152,6 +152,12 @@
       #startDate {
         max-width: 260px;
       }
+      #checkVideoResult {
+        white-space: pre-wrap;
+      }
+      #checkVideoResult code {
+        margin-right: 0.25rem;
+      }
     </style>
   </head>
   <body>
@@ -235,7 +241,7 @@
               </button>
             </div>
           </div>
-          <div id="checkVideoResult" class="mt-2"></div>
+          <div id="checkVideoResult" class="mt-2 box has-background-light"></div>
         </div>
 
         <h3 class="title is-4 mb-2" id="filtersHeader">Настройки фильтров</h3>

--- a/src/settings/settings.html
+++ b/src/settings/settings.html
@@ -235,7 +235,7 @@
               </button>
             </div>
           </div>
-          <pre id="checkVideoResult" class="mt-2"></pre>
+          <div id="checkVideoResult" class="mt-2"></div>
         </div>
 
         <h3 class="title is-4 mb-2" id="filtersHeader">Настройки фильтров</h3>

--- a/src/settings/settings.js
+++ b/src/settings/settings.js
@@ -182,7 +182,7 @@ document.addEventListener("DOMContentLoaded", async () => {
           row.appendChild(b);
           const span = document.createElement("span");
           if (Array.isArray(value)) {
-            span.textContent = value.map((v) => `"${v}"`).join(" ");
+            span.textContent = value.map((v) => `"${v}"`).join(", ");
           } else {
             span.textContent = value;
             if (label === "Описание") span.style.whiteSpace = "pre-wrap";

--- a/src/settings/settings.js
+++ b/src/settings/settings.js
@@ -114,6 +114,9 @@ document.addEventListener("DOMContentLoaded", async () => {
   const saveBtn = document.getElementById("saveStartDate");
   const videoInput = document.getElementById("videoId");
   const useBtn = document.getElementById("useVideoId");
+  const checkVideoInput = document.getElementById("checkVideoInput");
+  const checkVideoBtn = document.getElementById("checkVideoBtn");
+  const checkVideoResult = document.getElementById("checkVideoResult");
   const filtersContainer = document.getElementById("filtersContainer");
   const globalContainer = document.getElementById("globalFilters");
   const saveFiltersBtn = document.getElementById("saveFilters");
@@ -157,6 +160,23 @@ document.addEventListener("DOMContentLoaded", async () => {
         if (response && response.date) {
           const d = new Date(response.date);
           startInput.value = toLocalInputValue(d);
+        }
+      }
+    );
+  });
+
+  checkVideoBtn?.addEventListener("click", () => {
+    const id = parseVideoId(checkVideoInput.value);
+    if (!id) return;
+    checkVideoResult.textContent = "Loading...";
+    chrome.runtime.sendMessage(
+      { type: "videoInfo", videoId: id },
+      (resp) => {
+        if (resp && resp.info) {
+          checkVideoResult.textContent = JSON.stringify(resp.info, null, 2);
+        } else {
+          checkVideoResult.textContent =
+            "Error: " + (resp?.error || "unknown");
         }
       }
     );

--- a/src/settings/settings.js
+++ b/src/settings/settings.js
@@ -174,14 +174,25 @@ document.addEventListener("DOMContentLoaded", async () => {
       if (resp && resp.info) {
         const info = resp.info;
         const addLine = (label, value) => {
-          if (!value && value !== 0) return;
+          if (value === undefined || value === null) return;
           const row = document.createElement("div");
+          row.className = "mb-1";
           const b = document.createElement("b");
           b.textContent = label + ": ";
           row.appendChild(b);
-          const span = document.createElement("span");
-          span.textContent = value;
-          row.appendChild(span);
+          if (Array.isArray(value)) {
+            value.forEach((v, i) => {
+              const code = document.createElement("code");
+              code.textContent = v;
+              row.appendChild(code);
+              if (i < value.length - 1) row.appendChild(document.createTextNode(" "));
+            });
+          } else {
+            const span = document.createElement("span");
+            span.textContent = value;
+            if (label === "Описание") span.style.whiteSpace = "pre-wrap";
+            row.appendChild(span);
+          }
           checkVideoResult.appendChild(row);
         };
 
@@ -190,11 +201,7 @@ document.addEventListener("DOMContentLoaded", async () => {
           addLine("Канал", `${info.channelTitle} (${info.channelId})`);
         addLine("Название", info.title);
         addLine("Описание", info.description);
-        if (info.tags && info.tags.length)
-          addLine(
-            "Теги",
-            info.tags.map((t) => `"${t}"`).join(", ")
-          );
+        if (info.tags && info.tags.length) addLine("Теги", info.tags);
         if (info.duration)
           addLine(
             "Длительность",

--- a/src/settings/settings.js
+++ b/src/settings/settings.js
@@ -169,17 +169,31 @@ document.addEventListener("DOMContentLoaded", async () => {
     const id = parseVideoId(checkVideoInput.value);
     if (!id) return;
     checkVideoResult.textContent = "Loading...";
-    chrome.runtime.sendMessage(
-      { type: "videoInfo", videoId: id },
-      (resp) => {
-        if (resp && resp.info) {
-          checkVideoResult.textContent = JSON.stringify(resp.info, null, 2);
-        } else {
-          checkVideoResult.textContent =
-            "Error: " + (resp?.error || "unknown");
+    chrome.runtime.sendMessage({ type: "videoInfo", videoId: id }, (resp) => {
+      if (resp && resp.info) {
+        const info = resp.info;
+        const lines = [];
+        lines.push(`ID: ${info.id}`);
+        if (info.channelTitle) {
+          lines.push(`Канал: ${info.channelTitle} (${info.channelId})`);
         }
+        if (info.title) lines.push(`Название: ${info.title}`);
+        if (info.tags && info.tags.length)
+          lines.push(`Теги: ${info.tags.join(", ")}`);
+        if (info.duration) lines.push(`Длительность: ${info.duration}`);
+        if (info.publishedAt)
+          lines.push(
+            `Опубликовано: ${new Date(info.publishedAt).toLocaleString("ru")}`
+          );
+        if (info.scheduled)
+          lines.push(`Запланировано: ${info.scheduled}`);
+        if (info.actual) lines.push(`Начало трансляции: ${info.actual}`);
+        checkVideoResult.textContent = lines.join("\n");
+      } else {
+        checkVideoResult.textContent =
+          "Error: " + (resp?.error || "unknown");
       }
-    );
+    });
   });
 
   const filters = await getFilters();

--- a/src/settings/settings.js
+++ b/src/settings/settings.js
@@ -180,19 +180,14 @@ document.addEventListener("DOMContentLoaded", async () => {
           const b = document.createElement("b");
           b.textContent = label + ": ";
           row.appendChild(b);
+          const span = document.createElement("span");
           if (Array.isArray(value)) {
-            value.forEach((v, i) => {
-              const code = document.createElement("code");
-              code.textContent = v;
-              row.appendChild(code);
-              if (i < value.length - 1) row.appendChild(document.createTextNode(" "));
-            });
+            span.textContent = value.map((v) => `"${v}"`).join(" ");
           } else {
-            const span = document.createElement("span");
             span.textContent = value;
             if (label === "Описание") span.style.whiteSpace = "pre-wrap";
-            row.appendChild(span);
           }
+          row.appendChild(span);
           checkVideoResult.appendChild(row);
         };
 
@@ -200,7 +195,6 @@ document.addEventListener("DOMContentLoaded", async () => {
         if (info.channelTitle)
           addLine("Канал", `${info.channelTitle} (${info.channelId})`);
         addLine("Название", info.title);
-        addLine("Описание", info.description);
         if (info.tags && info.tags.length) addLine("Теги", info.tags);
         if (info.duration)
           addLine(
@@ -216,6 +210,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         addLine("Трансляция", info.broadcast ? "Да" : "Нет");
         if (info.scheduled) addLine("Запланировано", info.scheduled);
         if (info.actual) addLine("Начало трансляции", info.actual);
+        addLine("Описание", info.description);
       } else {
         checkVideoResult.textContent =
           "Error: " + (resp?.error || "unknown");


### PR DESCRIPTION
## Summary
- add UI on settings page to check video information
- fetch video data through new message type

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68583ed211588326aced8dbf3985013b